### PR TITLE
Fix deprecation warnings for chef 13 when accessing nodes

### DIFF
--- a/knife-chef-inventory.gemspec
+++ b/knife-chef-inventory.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "~> 2.1"
 
-  s.add_dependency "chef", "<= 12.11.18"
+  s.add_dependency "chef", "~> 12.11"
 
   s.add_development_dependency "bundler", "~> 1.6"
   s.add_development_dependency "rake", "~> 11.1"

--- a/lib/chef/knife/inventory_chef_client.rb
+++ b/lib/chef/knife/inventory_chef_client.rb
@@ -42,7 +42,7 @@ class Chef
       def client_usage_per_version
         version_map = Hash.new(0)
         all_nodes.each do |node|
-          version = node.chef_packages.chef.version
+          version = node["chef_packages"]["chef"]["version"]
 
           version_map[version] += 1
         end
@@ -67,8 +67,8 @@ class Chef
 
       def output_version_analysis
         ui.info "Client Versions being used"
-        client_version_nodes.sort_by(&:ohai_time).each do |node|
-          ui.info "#{node.name} - #{time_since(node.ohai_time)} Minutes"
+        client_version_nodes.sort_by { |node| node["ohai_time"] }.each do |node|
+          ui.info "#{node.name} - #{time_since(node['ohai_time'])} Minutes"
         end
       end
 

--- a/lib/chef/knife/inventory_cookbook.rb
+++ b/lib/chef/knife/inventory_cookbook.rb
@@ -78,7 +78,7 @@ class Chef
       def cookbook_usage_per_version
         version_map = Hash.new(0)
         cookbook_nodes.each do |node|
-          version = node.cookbooks[@cookbook_name].version
+          version = node["cookbooks"][@cookbook_name]["version"]
 
           version_map[version] += 1
         end
@@ -110,8 +110,8 @@ class Chef
 
       def output_version_analysis
         ui.info "Cookbook Versions being used for #{@cookbook_name}"
-        cookbook_version_nodes.sort_by(&:ohai_time).each do |node|
-          ui.info "#{node.name} - #{time_since(node.ohai_time)} Minutes"
+        cookbook_version_nodes.sort_by { |node| node["ohai_time"] }.each do |node|
+          ui.info "#{node.name} - #{time_since(node['ohai_time'])} Minutes"
         end
       end
 


### PR DESCRIPTION
This fixes the errors for versions of chef higher than 12.11.\* where you would see the following:

```
WARN: method access to node attributes (node.foo.bar) is deprecated and will be removed in Chef 13, please use bracket syntax (node["foo"]["bar"])
```
