### PR TITLE
Improve performance by switching to partial search

### DIFF
--- a/lib/knife-chef-inventory/shared.rb
+++ b/lib/knife-chef-inventory/shared.rb
@@ -1,0 +1,15 @@
+module KnifeChefInventory
+  module Shared
+    def time_since(timestamp)
+      (Time.now - Time.at(timestamp)).to_i / 60
+    end
+
+    def search_nodes(query)
+      Chef::Search::Query.new.search(:node, query, search_args).first
+    end
+
+    def max_results
+      Chef::Node.list.count || 1000
+    end
+  end
+end


### PR DESCRIPTION
This updates the chef node searches to use partial searches which should help serialization and memory usage locally.

``` bash
# Before
bundle exec knife inventory chef_client  16.52s user 0.93s system 82% cpu 21.159 total

#After
bundle exec knife inventory chef_client  0.69s user 0.16s system 8% cpu 10.479 total
```
