### PR TITLE
check if cb doesnt exist

### DIFF
--- a/lib/chef/knife/inventory_chef_client.rb
+++ b/lib/chef/knife/inventory_chef_client.rb
@@ -43,7 +43,7 @@ class Chef
           rows: max_results,
           filter_result: {
             name: ["name"],
-            chef_version: %w[chef_packages chef version],
+            chef_version: %w(chef_packages chef version),
             ohai_time: ["ohai_time"]
           }
         }

--- a/lib/chef/knife/inventory_cookbook.rb
+++ b/lib/chef/knife/inventory_cookbook.rb
@@ -29,7 +29,7 @@ class Chef
 
         if @cookbook_name
           cookbook_object = search_nodes("cookbooks_#{@cookbook_name}:*")
-          if cookbook_object.to_s == '[]'
+          if cookbook_object.to_s == "[]"
             ui.fatal "The cookbook name you provided #{cookbook_name} does not exist on the Chef server."
             show_usage
             exit 1

--- a/lib/chef/knife/inventory_cookbook.rb
+++ b/lib/chef/knife/inventory_cookbook.rb
@@ -26,8 +26,16 @@ class Chef
         @cookbook_version = name_args[1]
         @show_env_constraints = config[:env_constraints]
 
-        unless @cookbook_name
-          ui.error "You need to specify a cookbook"
+        if @cookbook_name
+          cookbook_object = search_nodes("cookbooks_#{@cookbook_name}:*")
+          if cookbook_object.to_s == '[]'
+            ui.fatal "The cookbook name you provided #{cookbook_name} does not exist on the Chef server."
+            show_usage
+            exit 1
+          end
+        else
+          ui.fatal "You did not specify a cookbook. You need to specify a cookbook."
+          show_usage
           exit 1
         end
 

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -7,9 +7,9 @@ begin
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.future_release = "v#{Knife::ChefInventory::VERSION}"
     config.issues = false
-    config.enhancement_labels = %w[enhancement]
-    config.bug_labels = %w[bug]
-    config.exclude_labels = %w[no_changelog]
+    config.enhancement_labels = %w(enhancement)
+    config.bug_labels = %w(bug)
+    config.exclude_labels = %w(no_changelog)
   end
 rescue LoadError
   puts "Problem loading gems please install chef and github_changelog_generator"


### PR DESCRIPTION
Based off of https://github.com/brentm5/knife-chef-inventory/issues/5 

If the cookbook doesn't exist, the object which forms as a result of this query / api call 
search_nodes("cookbooks_#{@cookbook_name}:*") is []

I tried comparing it to nil ( because that's what i think is going on here) and other things but i couldn't get it to work ( ruby noob ) 
comparing against a string '[]' works and if the cookbook wasn't found, we error out and exit. 

I dunno if we have to run like a lintt status checker, update the gem version etc. etc. cause this is the first time I'm doing this, but I think we might have to, let me know!

